### PR TITLE
docs: manualler.md oluşturuldu ve intel geliştirici kılavuzu eklendi

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -9,7 +9,7 @@ Bir kaynak eklerken yalnızca bağlantıyı vermek yeterli değildir: kaynağın
 | Konu | Dosya | Durum |
 | --- | --- | --- |
 | Kitaplar | `kitaplar.md` | ⬜ |
-| Mimari manual'ları (Intel, AMD, ARM, RISC-V) | `manualler.md` | ⬜ |
+| Mimari manual'ları (Intel, AMD, ARM, RISC-V) | `manualler.md` | 🟡 |
 | Spesifikasyonlar (UEFI, ACPI, PCI, USB, RFC'ler) | `spesifikasyonlar.md` | ⬜ |
 | Makaleler ve akademik yayınlar | `makaleler.md` | ⬜ |
 | İncelenebilecek açık kaynak projeler | `projeler.md` | ⬜ |

--- a/resources/README.md
+++ b/resources/README.md
@@ -9,7 +9,7 @@ Bir kaynak eklerken yalnızca bağlantıyı vermek yeterli değildir: kaynağın
 | Konu | Dosya | Durum |
 | --- | --- | --- |
 | Kitaplar | `kitaplar.md` | ⬜ |
-| Mimari manual'ları (Intel, AMD, ARM, RISC-V) | `manualler.md` | 🟡 |
+| [Mimari manual'ları (Intel, AMD, ARM, RISC-V)](./manualler.md) | `manualler.md` | 🟡 |
 | Spesifikasyonlar (UEFI, ACPI, PCI, USB, RFC'ler) | `spesifikasyonlar.md` | ⬜ |
 | Makaleler ve akademik yayınlar | `makaleler.md` | ⬜ |
 | İncelenebilecek açık kaynak projeler | `projeler.md` | ⬜ |

--- a/resources/manualler.md
+++ b/resources/manualler.md
@@ -1,0 +1,10 @@
+# Mimari kılavuzları
+
+## Intel® 64 and IA-32 Architectures Software Developer Manual `[x86_64]`
+
+x86_64 ve IA-32 için Intel tarafından hazırlanan resmi yazılım geliştirme kılavuzudur. İçinde x86 buyruk kümesi, çalışma ortamı, çeşitli veri yapıları, girdi-çıktı vb. konularda neredeyse her sorunun cevabı var. Bu mimari hedefleniyorsa hazırda bulundurulması büyük kolaylık sağlayacaktır.
+
+Baştan sona okunmak için değildir, konuyla alakalı maddelerin içindekiler kısmından seçilip incelenmesi önerilir.
+
+- [🔗Resmi sayfa](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)
+- [🔗İndirme bağlantısı (PDF)](https://cdrdv2.intel.com/v1/dl/getContent/671200) (bütün ciltlerin birleştirilmiş sürümü). Ayrı halleri için resmi sayfayı ziyaret edin.


### PR DESCRIPTION
# Değişiklik özeti
Kaynaklar (`resources`) dizininde `manualler.md` dosyasını oluşturuldu ve Intel'in kılavuzları eklendi.

İlgili issue: #3 

## Değişikliğin türü

- [ ] Yeni not
- [ ] Mevcut notta düzeltme (teknik hata)
- [ ] Mevcut notta iyileştirme (anlatım, örnek, ek açıklama)
- [X] Kaynak ekleme
- [ ] Terimler sözlüğü değişikliği
- [ ] Repository düzeni / altyapı

## Kontrol listesi

- [ ] Not [SABLON.md](https://github.com/TurkOsdev/osdev-notlari/blob/main/SABLON.md) yapısına uyuyor.
- [ ] Notun sonunda **Kaynaklar** başlığı var ve kaynaklar birincil (manual, spesifikasyon, resmi dokümantasyon).
> Bir kaynağın kendisi eklendiği için ayrıca bu başlık eklenmedi.
- [X] Terimler [TERIMLER.md](https://github.com/TurkOsdev/osdev-notlari/blob/main/TERIMLER.md) ile tutarlı; sözlükte olmayan terimler eklendi.
- [X] Dosya adı kurallara uygun: küçük harf, tire, Türkçe karakter yok.
- [X] Bölüm README'sindeki tablo güncellendi (durum ✅, dosya adı bağlantıya dönüştürüldü).
- [X] Tüm bağlantılar çalışıyor. (indirme bağlantısı halka açık, resmi sayfadan kopyalandı)
- [X] Yazım denetimi yapıldı.

## Kullanılan kaynaklar
Intel® 64 and IA-32 Architectures Software Developer’s Manual

## Emin olmadığınız yerler
Kaynaklar dizini için açıkça belirlenmiş bir şablon yoktu, mevcut şablon teknik notlar için daha uygundu ve burada çok işlevli olmazdı. Tek birincil başlık kuralını devam ettirdim, buraya elbet başka mimariler de eklenecek o yüzden bu dosya özelinde bir kural belirlenirse iyi olabilir

Bu konuda bir düzeltme gerekirse buradayım :)
